### PR TITLE
Default ice transport policy to "all" when not present in event JSON

### DIFF
--- a/MembraneRTC/Sources/MembraneRTC/Events/Event.swift
+++ b/MembraneRTC/Sources/MembraneRTC/Events/Event.swift
@@ -298,6 +298,17 @@ struct OfferDataEvent: ReceivableEvent, Codable {
         let iceTransportPolicy: String
         let integratedTurnServers: [TurnServer]
         let tracksTypes: [String: Int]
+        
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.integratedTurnServers = try container.decode([TurnServer].self, forKey: .integratedTurnServers)
+            self.tracksTypes = try container.decode([String: Int].self, forKey: .tracksTypes)
+            if container.contains(.iceTransportPolicy) {
+                self.iceTransportPolicy = try container.decode(String.self, forKey: .iceTransportPolicy)
+            } else {
+                self.iceTransportPolicy = "all"
+            }
+        }
     }
 
     let type: ReceivableEventType


### PR DESCRIPTION
According to the specification `iceTransportPolicy` should be defaulted to `"all"` in case it's not present in a signaling event:

https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection