### PR TITLE
Map trackIdToMetadata for Peer to nil when not present in an Event JSON

### DIFF
--- a/MembraneRTC/Sources/MembraneRTC/Types/Peer.swift
+++ b/MembraneRTC/Sources/MembraneRTC/Types/Peer.swift
@@ -30,4 +30,15 @@ public struct Peer: Codable {
         
         return Peer(id: self.id, metadata: self.metadata, trackIdToMetadata: newTrackIdToMetadata)
     }
+    
+    enum CodingKeys: String, CodingKey {
+        case id, metadata, trackIdToMetadata
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.metadata = try container.decode(Metadata.self, forKey: .metadata)
+        self.trackIdToMetadata = try container.decodeIfPresent([String: Metadata].self, forKey: .trackIdToMetadata)
+    }
 }


### PR DESCRIPTION
Optional values with `Codable` are not automatically translated to `nil` when the key is not present in a JSON

https://forums.swift.org/t/decoding-of-optionals-missing-in-json/52475