### PR TITLE
Increase IPC timeout to 5 seconds

### DIFF
--- a/MembraneRTC/Sources/MembraneRTC/Media/Capturers/ScreenBroadcastCapturer.swift
+++ b/MembraneRTC/Sources/MembraneRTC/Media/Capturers/ScreenBroadcastCapturer.swift
@@ -105,10 +105,10 @@ class ScreenBroadcastCapturer: RTCVideoCapturer, VideoCapturer {
 
         super.init(delegate: source)
 
-        // check every 2 seconds if the screensharing is still active or crashed
+        // check every 5 seconds if the screensharing is still active or crashed
         // this is needed as we can't know if the IPC Client stopped working or not, so at least
         // we can check that that we receiving some samples
-        timeoutTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] timer in
+        timeoutTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] timer in
             guard let self = self else {
                 timer.invalidate()
                 return


### PR DESCRIPTION
This is needed because the system broadcast picker view is counting down from 3 seconds which can be done in background. 2 seconds timer would falsely error out in case the user comes back to the app right away (5 sec as a safety, it's not too common for the IPC to crash, we can afford that IMO)